### PR TITLE
fix: vkvs encoder backend generates y4m

### DIFF
--- a/soothe/encoder.py
+++ b/soothe/encoder.py
@@ -48,6 +48,7 @@ class Encoder(NamedClass):
             output_file: str,
             timeout: int,
             verbose: bool,
+            keep_files: bool,
     ):
         """Encodes input_file in output_file"""
         raise NotImplementedError

--- a/soothe/encoders/dummy.py
+++ b/soothe/encoders/dummy.py
@@ -39,6 +39,7 @@ class Dummy(Encoder):
             output_file: str,
             timeout: int,
             verbose: bool,
+            keep_files: bool,
     ):
         """Copies input_file to output_file"""
 

--- a/soothe/encoders/gstreamer.py
+++ b/soothe/encoders/gstreamer.py
@@ -87,6 +87,7 @@ class GStreamer(Encoder):
             output_file: str,
             timeout: int,
             verbose: bool,
+            keep_files: bool,
     ):
         """Encodes input_file in output_file"""
 

--- a/soothe/encoders/vk_video_encoder.py
+++ b/soothe/encoders/vk_video_encoder.py
@@ -21,6 +21,7 @@
 
 """Module for Vulkan Video Samples based encoders"""
 
+import os
 import shlex
 import subprocess
 
@@ -107,6 +108,7 @@ class VKVS(Encoder):
             output_file: str,
             timeout: int,
             verbose: bool,
+            keep_files: bool,
     ):
         """Encodes input_file in output_file"""
         encoded_file = f"{output_file}.enc"
@@ -114,6 +116,10 @@ class VKVS(Encoder):
         run_command(shlex.split(enc_cmd), timeout=timeout, verbose=verbose)
         dec_cmd = self._construct_dec_cmd(encoded_file, output_file)
         run_command(shlex.split(dec_cmd), timeout=timeout, verbose=verbose)
+        if not keep_files \
+           and os.path.exists(encoded_file) \
+           and os.path.isfile(encoded_file):
+            os.remove(encoded_file)
 
 
 @register_encoder

--- a/soothe/test.py
+++ b/soothe/test.py
@@ -110,6 +110,7 @@ class Test:  # pylint: disable=too-few-public-methods
                 output_filepath,
                 self.params.timeout,
                 self.params.verbose,
+                self.params.keep_files
             )
             result.encode_time = perf_counter() - start
         except TimeoutExpired:


### PR DESCRIPTION
The backend needs to generate a y4m out of the encoding process using a decoder.
Use vk-video-dec-test for now.