### PR TITLE
Add reference decoders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 __pycache__/
 *.py[cod]
 resources/
+contrib/
+/decoders/
+/encoders/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 CONTRIB_DIR=contrib
 DECODERS_DIR=decoders
+ENCODERS_DIR=encoders
 SOOTHE=python3 ./soothe.py
 CMAKE_GENERATOR=Unix Makefiles
 
@@ -15,9 +16,9 @@ check: ## check that very basic tests run
 	$(SOOTHE) run -e dummy
 
 
-create_dirs=mkdir -p $(CONTRIB_DIR) $(DECODERS_DIR)
+create_dirs=mkdir -p $(CONTRIB_DIR) $(DECODERS_DIR) $(ENCODERS_DIR)
 
-all_reference_decoders: h264_reference_decoder h265_reference_decoder av1_reference_decoder vp9_reference_decoder  ## build all reference decoders
+all_reference_decoders: h264_reference_decoder h265_reference_decoder av1_reference_codec vp9_reference_codec  ## build all reference decoders
 
 h265_reference_decoder: ## build H.265 reference decoder
 	$(create_dirs)
@@ -33,18 +34,20 @@ h264_reference_decoder: ## build H.264 reference decoder
 	cd $(CONTRIB_DIR)/JM && cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-Wno-stringop-truncation -Wno-stringop-overflow" && $(MAKE) -C build ldecod
 	find $(CONTRIB_DIR)/JM/bin/umake -name "ldecod" -type f -exec cp {} $(DECODERS_DIR)/ \;
 
-av1_reference_decoder: ## build AV1 reference decoder
+av1_reference_codec: ## build AV1 reference decoder and encoder
 	$(create_dirs)
 	cd $(CONTRIB_DIR) && git clone --branch=v3.12.1 https://aomedia.googlesource.com/aom --depth=1 || true
 	cd $(CONTRIB_DIR)/aom && git stash && git pull && git stash apply || true
-	cd $(CONTRIB_DIR)/aom && cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release  -Wno-stringop-overflow && $(MAKE) -j -C build aomdec
+	cd $(CONTRIB_DIR)/aom && cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release  -Wno-stringop-overflow && $(MAKE) -j -C build
+	find $(CONTRIB_DIR)/ -name "aomenc" -type f -exec cp {} $(ENCODERS_DIR)/ \;
 	find $(CONTRIB_DIR)/ -name "aomdec" -type f -exec cp {} $(DECODERS_DIR)/ \;
 
-vp9_reference_decoder: ## build VP9 reference decoder
+vp9_reference_codec: ## build VP9 reference decoder and encoder
 	$(create_dirs)
 	cd $(CONTRIB_DIR) && git clone --branch=v1.15.2 https://chromium.googlesource.com/webm/libvpx --depth=1 || true
 	cd $(CONTRIB_DIR)/libvpx && git stash && git pull && git stash apply || true
 	cd $(CONTRIB_DIR)/libvpx && ./configure --disable-unit-tests --enable-vp9 && $(MAKE) -j
+	find $(CONTRIB_DIR)/libvpx -name "vpxenc" -type f -exec cp {} $(ENCODERS_DIR)/ \;
 	find $(CONTRIB_DIR)/libvpx -name "vpxdec" -type f -exec cp {} $(DECODERS_DIR)/ \;
 
 clean: ## remove contrib temporary folder
@@ -53,5 +56,5 @@ clean: ## remove contrib temporary folder
 dbg-%:
 	echo "Value of $* = $($*)"
 
-.PHONY: help all_reference_decoders h264_reference_decoder h265_reference_decoder av1_reference_decoder vp9_reference_decoder \
+.PHONY: help all_reference_decoders h264_reference_decoder h265_reference_decoder av1_reference_codec vp9_reference_codec \
 check install_deps clean

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,57 @@
+CONTRIB_DIR=contrib
+DECODERS_DIR=decoders
+SOOTHE=python3 ./soothe.py
+CMAKE_GENERATOR=Unix Makefiles
+
+help:
+	@awk -F ':|##' '/^[^\t].+?:.*?##/ { printf "\033[36m%-30s\033[0m %s\n", $$1, $$NF }' $(MAKEFILE_LIST)
+
+
+check: ## check that very basic tests run
+	@echo "Running dummy test..."
+	$(SOOTHE) list
+	$(SOOTHE) list -c
+	$(SOOTHE) download
+	$(SOOTHE) run -e dummy
+
+
+create_dirs=mkdir -p $(CONTRIB_DIR) $(DECODERS_DIR)
+
+all_reference_decoders: h264_reference_decoder h265_reference_decoder av1_reference_decoder vp9_reference_decoder  ## build all reference decoders
+
+h265_reference_decoder: ## build H.265 reference decoder
+	$(create_dirs)
+	cd $(CONTRIB_DIR) && git clone --branch=HM-18.0 https://vcgit.hhi.fraunhofer.de/jct-vc/HM.git --depth=1 || true
+	cd $(CONTRIB_DIR)/HM && git stash && git pull && git stash apply || true
+	cd $(CONTRIB_DIR)/HM && cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wno-array-bounds" && $(MAKE) -C build TAppDecoder
+	find $(CONTRIB_DIR)/HM/bin/umake -name "TAppDecoder" -type f -exec cp {} $(DECODERS_DIR)/ \;
+
+h264_reference_decoder: ## build H.264 reference decoder
+	$(create_dirs)
+	cd $(CONTRIB_DIR) && git clone --branch=JM-19.1 https://vcgit.hhi.fraunhofer.de/jct-vc/JM.git --depth=1 || true
+	cd $(CONTRIB_DIR)/JM && git stash && git pull && git stash apply || true
+	cd $(CONTRIB_DIR)/JM && cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-Wno-stringop-truncation -Wno-stringop-overflow" && $(MAKE) -C build ldecod
+	find $(CONTRIB_DIR)/JM/bin/umake -name "ldecod" -type f -exec cp {} $(DECODERS_DIR)/ \;
+
+av1_reference_decoder: ## build AV1 reference decoder
+	$(create_dirs)
+	cd $(CONTRIB_DIR) && git clone --branch=v3.12.1 https://aomedia.googlesource.com/aom --depth=1 || true
+	cd $(CONTRIB_DIR)/aom && git stash && git pull && git stash apply || true
+	cd $(CONTRIB_DIR)/aom && cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release  -Wno-stringop-overflow && $(MAKE) -j -C build aomdec
+	find $(CONTRIB_DIR)/ -name "aomdec" -type f -exec cp {} $(DECODERS_DIR)/ \;
+
+vp9_reference_decoder: ## build VP9 reference decoder
+	$(create_dirs)
+	cd $(CONTRIB_DIR) && git clone --branch=v1.15.2 https://chromium.googlesource.com/webm/libvpx --depth=1 || true
+	cd $(CONTRIB_DIR)/libvpx && git stash && git pull && git stash apply || true
+	cd $(CONTRIB_DIR)/libvpx && ./configure --disable-unit-tests --enable-vp9 && $(MAKE) -j
+	find $(CONTRIB_DIR)/libvpx -name "vpxdec" -type f -exec cp {} $(DECODERS_DIR)/ \;
+
+clean: ## remove contrib temporary folder
+	rm -rf $(CONTRIB_DIR)
+
+dbg-%:
+	echo "Value of $* = $($*)"
+
+.PHONY: help all_reference_decoders h264_reference_decoder h265_reference_decoder av1_reference_decoder vp9_reference_decoder \
+check install_deps clean

--- a/assets/media_xiph_org.json
+++ b/assets/media_xiph_org.json
@@ -8,7 +8,8 @@
       "checksum": "a4ef8836e546bbef4276346d0b86e81b",
       "filename": "blue_sky_1080p25.y4m",
       "width": 1920,
-      "height": 1080
+      "height": 1080,
+      "framerate": "25:1"
     },
     {
       "name": "four_people",
@@ -16,7 +17,8 @@
       "checksum": "83a3c203dc86fe8ecaa9010ad59f5757",
       "filename": "FourPeople_1280x720_60.y4m",
       "width": 1280,
-      "height": 720
+      "height": 720,
+      "framerate": "60:1"
     },
     {
       "name": "riverbed",
@@ -24,7 +26,8 @@
       "checksum": "9aeb08e3fe02e61d4a1b38be254ef293",
       "filename": "riverbed_1080p25.y4m",
       "width": 1920,
-      "height": 1080
+      "height": 1080,
+      "framerate": "25:1"
     },
     {
       "name": "station2",
@@ -32,7 +35,8 @@
       "checksum": "06be985bf3c2d986ecda3a331928da69",
       "filename": "station2_1080p25.y4m",
       "width": 1920,
-      "height": 1080
+      "height": 1080,
+      "framerate": "25:1"
     }
   ]
 }

--- a/assets/media_xiph_org.json
+++ b/assets/media_xiph_org.json
@@ -6,25 +6,33 @@
       "name": "blue_sky",
       "source": "https://media.xiph.org/video/derf/y4m/blue_sky_1080p25.y4m",
       "checksum": "a4ef8836e546bbef4276346d0b86e81b",
-      "filename": "blue_sky_1080p25.y4m"
+      "filename": "blue_sky_1080p25.y4m",
+      "width": 1920,
+      "height": 1080
     },
     {
       "name": "four_people",
       "source": "https://media.xiph.org/video/derf/y4m/FourPeople_1280x720_60.y4m",
       "checksum": "83a3c203dc86fe8ecaa9010ad59f5757",
-      "filename": "FourPeople_1280x720_60.y4m"
+      "filename": "FourPeople_1280x720_60.y4m",
+      "width": 1280,
+      "height": 720
     },
     {
       "name": "riverbed",
       "source": "https://media.xiph.org/video/derf/y4m/riverbed_1080p25.y4m",
       "checksum": "9aeb08e3fe02e61d4a1b38be254ef293",
-      "filename": "riverbed_1080p25.y4m"
+      "filename": "riverbed_1080p25.y4m",
+      "width": 1920,
+      "height": 1080
     },
     {
       "name": "station2",
       "source": "https://media.xiph.org/video/derf/y4m/station2_1080p25.y4m",
       "checksum": "06be985bf3c2d986ecda3a331928da69",
-      "filename": "station2_1080p25.y4m"
+      "filename": "station2_1080p25.y4m",
+      "width": 1920,
+      "height": 1080
     }
   ]
 }

--- a/soothe/asset.py
+++ b/soothe/asset.py
@@ -31,12 +31,16 @@ class Asset:
             source: str,
             checksum: str,
             filename: str,
+            width: int,
+            height: int,
     ):
         # JSON members
         self.name = name
         self.source = source
         self.checksum = checksum
         self.filename = filename
+        self.width = width
+        self.height = height
 
         # Not in JSON
         self.test_time = 0.0

--- a/soothe/asset.py
+++ b/soothe/asset.py
@@ -19,31 +19,25 @@
 
 """Module that holds an asset"""
 
+from dataclasses import dataclass, field
 from typing import Any, Type
 
 
+@dataclass
 class Asset:
     """Asset class"""
 
-    def __init__(
-            self,
-            name: str,
-            source: str,
-            checksum: str,
-            filename: str,
-            width: int,
-            height: int,
-    ):
-        # JSON members
-        self.name = name
-        self.source = source
-        self.checksum = checksum
-        self.filename = filename
-        self.width = width
-        self.height = height
+    # JSON members
+    name: str
+    source: str
+    checksum: str
+    filename: str
+    width: int
+    height: int
+    framerate: str
 
-        # Not in JSON
-        self.test_time = 0.0
+    # Not in JSON
+    test_time: float = field(default=0.0, init=False)
 
     @classmethod
     def from_json(cls: Type["Asset"], data: Any) -> Any:

--- a/soothe/decoder.py
+++ b/soothe/decoder.py
@@ -1,0 +1,99 @@
+# Soothe - testing framework for encoders quality
+# Copyright (C) 2020, Fluendo, S.A.
+#  Author: Pablo Marcos Oltra <pmarcos@fluendo.com>, Fluendo, S.A.
+# Copyright (C) 2025, Igalia, S.L.
+#  Author: Stéphane Cerveau <scerveau@igalia.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public License
+# as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library. If not, see <https://www.gnu.org/licenses/>.
+
+"""Module with the decoder abstract class and the list of available decoders"""
+
+
+from abc import ABC, abstractmethod
+from functools import lru_cache
+from shutil import which
+from typing import List, Optional, Type
+
+from .codec import Codec, OutputFormat
+from .utils import normalize_binary_cmd
+
+
+class Decoder(ABC):
+    """Base class for decoders"""
+
+    name = ""
+    codec = Codec.NONE
+    description = ""
+    binary = ""
+    is_reference = False
+    outputs_y4m = False  # True if decoder outputs Y4M, False for raw YUV
+
+    def __init__(self) -> None:
+        if self.binary:
+            self.binary = normalize_binary_cmd(self.binary)
+
+    @abstractmethod
+    def decode(
+        self,
+        input_filepath: str,
+        output_filepath: str,
+        output_format: OutputFormat,
+        *,
+        timeout: int,
+        verbose: bool,
+    ) -> str:
+        """Decodes input_filepath in output_filepath"""
+        raise NotImplementedError
+
+    @lru_cache(maxsize=128)
+    def check(self, verbose: bool) -> bool:
+        """Checks whether the decoder can be run"""
+        if hasattr(self, "binary") and self.binary:
+            try:
+                path = which(self.binary)
+                if verbose and not path:
+                    print(f"Binary {self.binary} can't be found to be "
+                          f"executed")
+
+                return path is not None
+            except OSError:
+                return False
+        return True
+
+    def __str__(self) -> str:
+        return f"    {self.name}: {self.description}"
+
+
+DECODERS: List[Decoder] = []
+
+
+def register_decoder(cls: Type[Decoder]) -> Type[Decoder]:
+    """Register a new decoder implementation"""
+    DECODERS.append(cls())
+    DECODERS.sort(key=lambda dec: dec.name)
+    return cls
+
+
+def get_reference_decoder_for_codec(codec: Codec) -> Optional["Decoder"]:
+    """Find the reference decoder for a specific codec"""
+
+    reference_decoders = [d for d in DECODERS if d.codec == codec and
+                          d.is_reference]
+
+    if not reference_decoders:
+        return None
+    if len(reference_decoders) > 1:
+        print(f"Multiple reference decoders found for codec {codec.name}")
+
+    return reference_decoders[0]

--- a/soothe/decoders/__init__.py
+++ b/soothe/decoders/__init__.py
@@ -1,8 +1,8 @@
 # Soothe - testing framework for encoders quality
 # Copyright (C) 2020, Fluendo, S.A.
 #  Author: Pablo Marcos Oltra <pmarcos@fluendo.com>, Fluendo, S.A.
-# Copyright (C) 2025, Igalia, S.L.
-#  Author: Victor Jaquez <vjaquez@igalia.com>
+# Copyright (C) 2026, Igalia, S.L.
+#  Author: Stéphane Cerveau <scerveau@igalia.com>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public License
@@ -17,29 +17,13 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library. If not, see <https://www.gnu.org/licenses/>.
 
-"""Codec module"""
+"""List of decoders"""
 
-from enum import Enum
+import glob
+import os.path
 
-
-class Codec(Enum):
-    """Codec type"""
-
-    NONE = "None"
-    DUMMY = "Dummy"
-    H264 = "H.264"
-    H265 = "H.265"
-    VP9 = "VP9"
-    AV1 = "AV1"
-
-    def __str__(self) -> str:
-        return self.value
-
-
-class OutputFormat(Enum):
-    """Output format"""
-
-    NONE = "None"
-    YUV420P = "yuv420p"
-    YUV420P10LE = "yuv420p10le"
-    UNKNOWN = "Unknown"
+modules = glob.glob(os.path.join(os.path.dirname(__file__), "*.py"))
+__all__ = [
+    os.path.basename(os.path.splitext(f)[0]) for f in modules
+    if os.path.isfile(f) and not f.endswith("__init__.py")
+]

--- a/soothe/decoders/av1_aom.py
+++ b/soothe/decoders/av1_aom.py
@@ -1,8 +1,9 @@
+"""libaom AV1 reference decoder"""
 # Soothe - testing framework for encoders quality
 # Copyright (C) 2020, Fluendo, S.A.
 #  Author: Pablo Marcos Oltra <pmarcos@fluendo.com>, Fluendo, S.A.
-# Copyright (C) 2025, Igalia, S.L.
-#  Author: Victor Jaquez <vjaquez@igalia.com>
+# Copyright (C) 2026, Igalia, S.L.
+#  Author: Stéphane Cerveau <scerveau@igalia.com>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public License
@@ -17,29 +18,17 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library. If not, see <https://www.gnu.org/licenses/>.
 
-"""Codec module"""
-
-from enum import Enum
-
-
-class Codec(Enum):
-    """Codec type"""
-
-    NONE = "None"
-    DUMMY = "Dummy"
-    H264 = "H.264"
-    H265 = "H.265"
-    VP9 = "VP9"
-    AV1 = "AV1"
-
-    def __str__(self) -> str:
-        return self.value
+from ..codec import Codec
+from ..decoder import register_decoder
+from .webm import WebMDecoder
 
 
-class OutputFormat(Enum):
-    """Output format"""
+@register_decoder
+class AV1AOMDecoder(WebMDecoder):
+    """libaom AV1 reference decoder implementation"""
 
-    NONE = "None"
-    YUV420P = "yuv420p"
-    YUV420P10LE = "yuv420p10le"
-    UNKNOWN = "Unknown"
+    name = "libaom-AV1"
+    description = "libaom AV1 reference decoder"
+    binary = "aomdec"
+    codec = Codec.AV1
+    is_reference = True

--- a/soothe/decoders/dummy.py
+++ b/soothe/decoders/dummy.py
@@ -1,0 +1,49 @@
+"""Dummy decoder for testing pipeline"""
+# Soothe - testing framework for encoders quality
+# Copyright (C) 2020, Fluendo, S.A.
+#  Author: Pablo Marcos Oltra <pmarcos@fluendo.com>, Fluendo, S.A.
+# Copyright (C) 2026, Igalia, S.L.
+#  Author: Stéphane Cerveau <scerveau@igalia.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public License
+# as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library. If not, see <https://www.gnu.org/licenses/>.
+
+import shutil
+
+from ..codec import Codec, OutputFormat
+from ..decoder import Decoder, register_decoder
+from ..utils import file_checksum
+
+
+@register_decoder
+class DummyDecoder(Decoder):
+    """Dummy decoder implementation for testing pipeline"""
+
+    name = "Dummy"
+    description = "Dummy decoder that copies input to output"
+    codec = Codec.DUMMY
+    is_reference = True
+    outputs_y4m = True
+
+    def decode(
+        self,
+        input_filepath: str,
+        output_filepath: str,
+        output_format: OutputFormat,
+        *,
+        timeout: int,
+        verbose: bool,
+    ) -> str:
+        """Copies input_filepath to output_filepath (dummy decode)"""
+        shutil.copyfile(input_filepath, output_filepath)
+        return file_checksum(output_filepath)

--- a/soothe/decoders/h264_jct_vt.py
+++ b/soothe/decoders/h264_jct_vt.py
@@ -1,8 +1,9 @@
+"""JCT-VT H.264/AVC reference decoder"""
 # Soothe - testing framework for encoders quality
 # Copyright (C) 2020, Fluendo, S.A.
 #  Author: Pablo Marcos Oltra <pmarcos@fluendo.com>, Fluendo, S.A.
-# Copyright (C) 2025, Igalia, S.L.
-#  Author: Victor Jaquez <vjaquez@igalia.com>
+# Copyright (C) 2026, Igalia, S.L.
+#  Author: Stéphane Cerveau <scerveau@igalia.com>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public License
@@ -17,29 +18,19 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library. If not, see <https://www.gnu.org/licenses/>.
 
-"""Codec module"""
-
-from enum import Enum
-
-
-class Codec(Enum):
-    """Codec type"""
-
-    NONE = "None"
-    DUMMY = "Dummy"
-    H264 = "H.264"
-    H265 = "H.265"
-    VP9 = "VP9"
-    AV1 = "AV1"
-
-    def __str__(self) -> str:
-        return self.value
+from ..codec import Codec
+from ..decoder import register_decoder
+from .jct_vt import JCTVTDecoder
 
 
-class OutputFormat(Enum):
-    """Output format"""
+@register_decoder
+class H264JCTVTDecoder(JCTVTDecoder):
+    """JCT-VT H.264/AVC reference decoder implementation"""
 
-    NONE = "None"
-    YUV420P = "yuv420p"
-    YUV420P10LE = "yuv420p10le"
-    UNKNOWN = "Unknown"
+    name = "JCT-VT-H.264"
+    description = "JCT-VT H.264/AVC reference decoder"
+    codec = Codec.H264
+    binary = "ldecod"
+    is_reference = True
+    input_flag = "-i"
+    extra_flags = ("-s",)

--- a/soothe/decoders/h265_jct_vt.py
+++ b/soothe/decoders/h265_jct_vt.py
@@ -1,8 +1,9 @@
+"""JCT-VT H.265/HEVC reference decoder"""
 # Soothe - testing framework for encoders quality
 # Copyright (C) 2020, Fluendo, S.A.
 #  Author: Pablo Marcos Oltra <pmarcos@fluendo.com>, Fluendo, S.A.
-# Copyright (C) 2025, Igalia, S.L.
-#  Author: Victor Jaquez <vjaquez@igalia.com>
+# Copyright (C) 2026, Igalia, S.L.
+#  Author: Stéphane Cerveau <scerveau@igalia.com>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public License
@@ -17,29 +18,18 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library. If not, see <https://www.gnu.org/licenses/>.
 
-"""Codec module"""
-
-from enum import Enum
-
-
-class Codec(Enum):
-    """Codec type"""
-
-    NONE = "None"
-    DUMMY = "Dummy"
-    H264 = "H.264"
-    H265 = "H.265"
-    VP9 = "VP9"
-    AV1 = "AV1"
-
-    def __str__(self) -> str:
-        return self.value
+from ..codec import Codec
+from ..decoder import register_decoder
+from .jct_vt import JCTVTDecoder
 
 
-class OutputFormat(Enum):
-    """Output format"""
+@register_decoder
+class H265JCTVTDecoder(JCTVTDecoder):
+    """JCT-VT H.265/HEVC reference decoder implementation"""
 
-    NONE = "None"
-    YUV420P = "yuv420p"
-    YUV420P10LE = "yuv420p10le"
-    UNKNOWN = "Unknown"
+    name = "JCT-VT-H.265"
+    description = "JCT-VT H.265/HEVC reference decoder"
+    codec = Codec.H265
+    binary = "TAppDecoder"
+    is_reference = True
+    input_flag = "-b"

--- a/soothe/decoders/jct_vt.py
+++ b/soothe/decoders/jct_vt.py
@@ -1,0 +1,54 @@
+"""Common base class for JCT-VT reference decoders"""
+# Soothe - testing framework for encoders quality
+# Copyright (C) 2020, Fluendo, S.A.
+#  Author: Pablo Marcos Oltra <pmarcos@fluendo.com>, Fluendo, S.A.
+# Copyright (C) 2026, Igalia, S.L.
+#  Author: Stéphane Cerveau <scerveau@igalia.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public License
+# as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library. If not, see <https://www.gnu.org/licenses/>.
+
+from typing import Tuple
+
+from ..codec import OutputFormat
+from ..decoder import Decoder
+from ..utils import file_checksum, run_command
+
+
+class JCTVTDecoder(Decoder):
+    """Base class for JCT-VT reference decoders (H.264, H.265)"""
+
+    input_flag: str = ""
+    extra_flags: Tuple[str, ...] = ()
+
+    def decode(
+        self,
+        input_filepath: str,
+        output_filepath: str,
+        output_format: OutputFormat,
+        *,
+        timeout: int,
+        verbose: bool,
+    ) -> str:
+        """Decodes input_filepath in output_filepath"""
+        cmd = [
+            self.binary,
+            *self.extra_flags,
+            self.input_flag,
+            input_filepath,
+            "-o",
+            output_filepath,
+        ]
+
+        run_command(cmd, timeout=timeout, verbose=verbose)
+        return file_checksum(output_filepath)

--- a/soothe/decoders/vp9_vpx.py
+++ b/soothe/decoders/vp9_vpx.py
@@ -1,8 +1,9 @@
+"""libvpx VP9 reference decoder"""
 # Soothe - testing framework for encoders quality
 # Copyright (C) 2020, Fluendo, S.A.
 #  Author: Pablo Marcos Oltra <pmarcos@fluendo.com>, Fluendo, S.A.
-# Copyright (C) 2025, Igalia, S.L.
-#  Author: Victor Jaquez <vjaquez@igalia.com>
+# Copyright (C) 2026, Igalia, S.L.
+#  Author: Stéphane Cerveau <scerveau@igalia.com>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public License
@@ -17,29 +18,17 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library. If not, see <https://www.gnu.org/licenses/>.
 
-"""Codec module"""
-
-from enum import Enum
-
-
-class Codec(Enum):
-    """Codec type"""
-
-    NONE = "None"
-    DUMMY = "Dummy"
-    H264 = "H.264"
-    H265 = "H.265"
-    VP9 = "VP9"
-    AV1 = "AV1"
-
-    def __str__(self) -> str:
-        return self.value
+from ..codec import Codec
+from ..decoder import register_decoder
+from .webm import WebMDecoder
 
 
-class OutputFormat(Enum):
-    """Output format"""
+@register_decoder
+class VP9VPXDecoder(WebMDecoder):
+    """libvpx VP9 reference decoder implementation"""
 
-    NONE = "None"
-    YUV420P = "yuv420p"
-    YUV420P10LE = "yuv420p10le"
-    UNKNOWN = "Unknown"
+    name = "libvpx-VP9"
+    description = "libvpx VP9 reference decoder"
+    binary = "vpxdec"
+    codec = Codec.VP9
+    is_reference = True

--- a/soothe/decoders/webm.py
+++ b/soothe/decoders/webm.py
@@ -1,0 +1,58 @@
+"""Common base class for WebM reference decoders (aomdec, vpxdec)"""
+# Soothe - testing framework for encoders quality
+# Copyright (C) 2020, Fluendo, S.A.
+#  Author: Pablo Marcos Oltra <pmarcos@fluendo.com>, Fluendo, S.A.
+# Copyright (C) 2026, Igalia, S.L.
+#  Author: Stéphane Cerveau <scerveau@igalia.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public License
+# as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library. If not, see <https://www.gnu.org/licenses/>.
+
+from typing import List
+
+from ..codec import OutputFormat
+from ..decoder import Decoder
+from ..utils import file_checksum, run_command
+
+
+class WebMDecoder(Decoder):
+    """Base class for WebM reference decoders (aomdec, vpxdec)"""
+
+    extra_args: List[str] = []
+
+    def decode(
+        self,
+        input_filepath: str,
+        output_filepath: str,
+        output_format: OutputFormat,
+        *,
+        timeout: int,
+        verbose: bool,
+    ) -> str:
+        """Decodes input_filepath in output_filepath"""
+        fmt = "--rawvideo"
+        if output_format in [OutputFormat.YUV420P,
+                             OutputFormat.YUV420P10LE]:
+            fmt = "--i420"
+
+        cmd = [
+            self.binary,
+            *self.extra_args,
+            fmt,
+            input_filepath,
+            "-o",
+            output_filepath,
+        ]
+
+        run_command(cmd, timeout=timeout, verbose=verbose)
+        return file_checksum(output_filepath)

--- a/soothe/encoder.py
+++ b/soothe/encoder.py
@@ -36,6 +36,7 @@ class Encoder(NamedClass):
     hw_acceleration: bool = False
     description: str = ""
     binary: str = ""
+    file_extension = ".bin"
 
     def __init__(self) -> None:
         if self.binary:
@@ -65,6 +66,10 @@ class Encoder(NamedClass):
     def name(self) -> str:
         """Encoder's name"""
         return self.encoder_name
+
+    def get_file_extension(self) -> str:
+        """Get the file extension for the encoder output"""
+        return self.file_extension
 
     def __str__(self) -> str:
         return f'{self.encoder_name}: {self.description}'

--- a/soothe/encoder.py
+++ b/soothe/encoder.py
@@ -37,6 +37,7 @@ class Encoder(NamedClass):
     description: str = ""
     binary: str = ""
     file_extension = ".bin"
+    is_reference: bool = False
 
     def __init__(self) -> None:
         if self.binary:

--- a/soothe/encoders/av1_aom.py
+++ b/soothe/encoders/av1_aom.py
@@ -1,0 +1,41 @@
+# Soothe - testing framework for encoders quality
+# Copyright (C) 2020, Fluendo, S.A.
+#  Author: Pablo Marcos Oltra <pmarcos@fluendo.com>, Fluendo, S.A.
+# Copyright (C) 2026, Igalia, S.L.
+#  Author: Stéphane Cerveau <scerveau@igalia.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public License
+# as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library. If not, see <https://www.gnu.org/licenses/>.
+
+"""Module for AV1 reference encoder"""
+
+from ..codec import Codec
+from ..encoder import register_encoder
+from .webm import WebMEncoder
+
+
+@register_encoder
+class AV1AOMEncoder(WebMEncoder):
+    """libaom AV1 reference encoder implementation"""
+    encoder_name = "libaom-AV1"
+    codec = Codec.AV1
+    description = "libaom AV1 reference encoder"
+    binary = "aomenc"
+    is_reference = True
+    extra_args = [
+        "--webm",
+        "--cpu-used=4",
+        "--end-usage=q",
+        "--cq-level=30",
+        "--threads=4",
+    ]

--- a/soothe/encoders/gstreamer.py
+++ b/soothe/encoders/gstreamer.py
@@ -31,8 +31,7 @@ from ..utils import normalize_binary_cmd, run_command
 
 PIPELINE_TPL = "{} --eos-on-shutdown --no-fault filesrc location={} ! "\
     "y4mdec ! videoconvert dither=none ! "\
-    "{} ! decodebin ! "\
-    "videoconvert dither=none ! y4menc ! filesink location={}"
+    "{} ! filesink location={}"
 
 
 class GStreamer(Encoder):
@@ -101,6 +100,7 @@ class GStreamerVaH264MainEncoder(GStreamer):
     encoder_bin = " vah264enc ! video/x-h264, profile=main "
     variant = "main"
     api = "VA"
+    file_extension = ".h264"
 
 
 @register_encoder
@@ -110,6 +110,7 @@ class GStreamerVaH264HighEncoder(GStreamer):
     encoder_bin = " vah264enc ! video/x-h264, profile=high "
     variant = "high"
     api = "VA"
+    file_extension = ".h264"
 
 
 @register_encoder
@@ -119,6 +120,7 @@ class GStreamerVaH264ConstrainedEncoder(GStreamer):
     encoder_bin = " vah264enc ! video/x-h264, profile=constrained-baseline "
     variant = "constrained-baseline"
     api = "VA"
+    file_extension = ".h264"
 
 
 @register_encoder
@@ -128,6 +130,7 @@ class GStreamerVaH264LpMainEncoder(GStreamer):
     encoder_bin = " vah264lpenc ! video/x-h264, profile=main "
     variant = "lp-main"
     api = "VA"
+    file_extension = ".h264"
 
 
 @register_encoder
@@ -137,6 +140,7 @@ class GStreamerVaH264LpHighEncoder(GStreamer):
     encoder_bin = " vah264lpenc ! video/x-h264, profile=high "
     variant = "lp-high"
     api = "VA"
+    file_extension = ".h264"
 
 
 @register_encoder
@@ -146,6 +150,7 @@ class GStreamerVaH264LpConstrainedEncoder(GStreamer):
     encoder_bin = " vah264lpenc ! video/x-h264, profile=constrained-baseline "
     variant = "lp-constrained-baseline"
     api = "VA"
+    file_extension = ".h264"
 
 
 @register_encoder
@@ -155,6 +160,7 @@ class GStreamerVaH265MainEncoder(GStreamer):
     encoder_bin = " vah265enc ! video/x-h265, profile=main "
     variant = "main"
     api = "VA"
+    file_extension = ".h265"
 
 
 @register_encoder
@@ -164,12 +170,14 @@ class GStreamerVaH265LpMainEncoder(GStreamer):
     encoder_bin = " vah265lpenc ! video/x-h265, profile=main "
     variant = "lp-main"
     api = "VA"
+    file_extension = ".h265"
 
 
 @register_encoder
 class GStreamerVaVp9LpEncoder(GStreamer):
     """GStreamer VP9 low power VA encoder"""
     codec = Codec.VP9
-    encoder_bin = " vavp9lpenc ! video/x-vp9 "
+    encoder_bin = " vavp9lpenc ! video/x-vp9 ! webmmux"
     variant = "lp"
     api = "VA"
+    file_extension = ".webm"

--- a/soothe/encoders/vk_video_encoder.py
+++ b/soothe/encoders/vk_video_encoder.py
@@ -103,6 +103,7 @@ class VKVSH264MainEncoder(VKVS):
     """Vulkan Video samples H.264 Main encoder"""
     codec = Codec.H264
     variant = "main"
+    file_extension = ".h264"
 
 
 @register_encoder
@@ -110,6 +111,7 @@ class VKVSH265MainEncoder(VKVS):
     """VKVS H.265 Main encoder"""
     codec = Codec.H265
     variant = "main"
+    file_extension = ".h265"
 
 
 @register_encoder
@@ -117,3 +119,4 @@ class VKVSAV1MainEncoder(VKVS):
     """VKVS AV1 Main encoder"""
     codec = Codec.AV1
     variant = "main"
+    file_extension = ".ivf"

--- a/soothe/encoders/vp9_vpx.py
+++ b/soothe/encoders/vp9_vpx.py
@@ -1,0 +1,43 @@
+# Soothe - testing framework for encoders quality
+# Copyright (C) 2020, Fluendo, S.A.
+#  Author: Pablo Marcos Oltra <pmarcos@fluendo.com>, Fluendo, S.A.
+# Copyright (C) 2026, Igalia, S.L.
+#  Author: Stéphane Cerveau <scerveau@igalia.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public License
+# as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library. If not, see <https://www.gnu.org/licenses/>.
+
+"""Module for VP9 reference encoder"""
+
+from ..codec import Codec
+from ..encoder import register_encoder
+from .webm import WebMEncoder
+
+
+@register_encoder
+class VP9VPXEncoder(WebMEncoder):
+    """libvpx VP9 reference encoder implementation"""
+    encoder_name = "libvpx-VP9"
+    codec = Codec.VP9
+    description = "libvpx VP9 reference encoder"
+    binary = "vpxenc"
+    is_reference = True
+    extra_args = [
+        "--codec=vp9",
+        "--good",
+        "--cpu-used=4",
+        "--end-usage=q",
+        "--cq-level=30",
+        "--threads=4",
+        "--webm",
+    ]

--- a/soothe/encoders/webm.py
+++ b/soothe/encoders/webm.py
@@ -1,0 +1,49 @@
+"""Common base class for WebM reference encoders (aomenc, vpxenc)"""
+# Soothe - testing framework for encoders quality
+# Copyright (C) 2020, Fluendo, S.A.
+#  Author: Pablo Marcos Oltra <pmarcos@fluendo.com>, Fluendo, S.A.
+# Copyright (C) 2026, Igalia, S.L.
+#  Author: Stéphane Cerveau <scerveau@igalia.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public License
+# as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library. If not, see <https://www.gnu.org/licenses/>.
+
+from typing import List
+
+from ..encoder import Encoder
+from ..utils import run_command
+
+
+class WebMEncoder(Encoder):
+    """Base class for WebM reference encoders (aomenc, vpxenc)"""
+
+    file_extension = ".webm"
+    extra_args: List[str] = []
+
+    def encode(
+        self,
+        input_file: str,
+        output_file: str,
+        timeout: int,
+        verbose: bool,
+    ):
+        """Encodes input_file in output_file"""
+        cmd = [
+            self.binary,
+            *self.extra_args,
+            "-o",
+            output_file,
+            input_file,
+        ]
+
+        run_command(cmd, timeout=timeout, verbose=verbose)

--- a/soothe/main.py
+++ b/soothe/main.py
@@ -31,6 +31,7 @@ from .soothe import RunParams, Soothe
 
 APPNAME = "soothe"
 ASSETS_DIR = "assets"
+DECODERS_DIR = "decoders"
 RESOURCES_DIR = "resources"
 OUTPUT_DIR = "soothe_output"
 ENCODERS_DIR = "encoders"
@@ -46,6 +47,7 @@ class Main:  # pylint: disable=too-few-public-methods
     """Main class for Soothe"""
 
     def __init__(self) -> None:
+        self.decoders_dir = DECODERS_DIR
         self.assets_dir = os.path.join(os.path.dirname(__file__), '..',
                                        ASSETS_DIR)
         self.resources_dir = os.path.join(os.path.dirname(__file__), '..',
@@ -53,6 +55,10 @@ class Main:  # pylint: disable=too-few-public-methods
         self.output_dir = os.path.join(gettempdir(), OUTPUT_DIR)
 
         self.args = self._create_argument_parser()
+
+        # Prepend to the PATH the decoders_dir so that we can run them
+        # without having to set the env for every single command
+        os.environ["PATH"] = self.decoders_dir + os.path.pathsep + os.environ["PATH"]
 
     def run(self) -> None:
         """Run Soothe"""

--- a/soothe/main.py
+++ b/soothe/main.py
@@ -47,6 +47,7 @@ class Main:  # pylint: disable=too-few-public-methods
     """Main class for Soothe"""
 
     def __init__(self) -> None:
+        self.encoders_dir = ENCODERS_DIR
         self.decoders_dir = DECODERS_DIR
         self.assets_dir = os.path.join(os.path.dirname(__file__), '..',
                                        ASSETS_DIR)
@@ -56,9 +57,12 @@ class Main:  # pylint: disable=too-few-public-methods
 
         self.args = self._create_argument_parser()
 
-        # Prepend to the PATH the decoders_dir so that we can run them
+        # Prepend to the PATH the encoders_dir and decoders_dir so that we can
+        # run them
         # without having to set the env for every single command
-        os.environ["PATH"] = self.decoders_dir + os.path.pathsep + os.environ["PATH"]
+        os.environ["PATH"] = (self.encoders_dir + os.path.pathsep +
+                              self.decoders_dir + os.path.pathsep +
+                              os.environ["PATH"])
 
     def run(self) -> None:
         """Run Soothe"""

--- a/soothe/soothe.py
+++ b/soothe/soothe.py
@@ -33,8 +33,11 @@ from .encoder import ENCODERS
 from .test_suite import TestSuite, Params as TestSuiteParams
 from .utils import get_matches_from_list
 
-# Import decoders that will auto-register
+# Import encoders that will auto-register
 from .encoders import *  # noqa: F401,F403,E501 pylint: disable=wildcard-import disable=unused-wildcard-import
+
+# Import decoders that will auto-register
+from .decoders import *  # noqa: F401,F403,E501 pylint: disable=wildcard-import disable=unused-wildcard-import
 
 
 @dataclass

--- a/soothe/soothe.py
+++ b/soothe/soothe.py
@@ -257,6 +257,8 @@ class Soothe:
         print('\nList of available encoders:')
         for encoder in ENCODERS:
             string = f'{encoder}'
+            if hasattr(encoder, 'is_reference') and encoder.is_reference:
+                string += ' [REFERENCE]'
             if check:
                 string += ' … ' + (
                     '✓' if encoder.check(verbose) else '𐄂'

--- a/soothe/test.py
+++ b/soothe/test.py
@@ -198,7 +198,8 @@ class Test:  # pylint: disable=too-few-public-methods
                                 decoded_filepath,
                                 y4m_filepath,
                                 asset.width,
-                                asset.height
+                                asset.height,
+                                framerate=asset.framerate
                             )
                             # Delete the YUV file after successful conversion
                             os.remove(decoded_filepath)

--- a/soothe/test.py
+++ b/soothe/test.py
@@ -30,6 +30,8 @@ from typing import Optional, Tuple
 
 from .asset import Asset
 from .encoder import Encoder
+from .decoder import get_reference_decoder_for_codec
+from .codec import OutputFormat
 from .utils import normalize_path, run_command_with_output
 
 
@@ -47,7 +49,7 @@ class Params:  # pylint: disable=too-many-instance-attributes
     verbose: bool = False
 
 
-class EncodeTestResult(Enum):
+class CodecTestResult(Enum):
     """Encode test result"""
 
     NOT_RUN = "Not Run"
@@ -64,18 +66,22 @@ class Result:
     asset_fname: Optional[str] = None
     encoder_name: Optional[str] = None
     encode_time: float = 0.0
-    encode_result: EncodeTestResult = EncodeTestResult.NOT_RUN
-    vmaf_result: EncodeTestResult = EncodeTestResult.NOT_RUN
+    encode_result: CodecTestResult = CodecTestResult.NOT_RUN
+    decode_result: CodecTestResult = CodecTestResult.NOT_RUN
+    decode_time: float = 0.0
+    vmaf_result: CodecTestResult = CodecTestResult.NOT_RUN
     vmaf_score: float = 0.0
     vmaf_time: float = 0.0
 
     def __str__(self):
         s = f'{self.encoder_name} — {self.asset_fname} '
-        if self.encode_result is not EncodeTestResult.SUCCESS:
+        if self.encode_result is not CodecTestResult.SUCCESS:
             return f'{s} → Encode {self.encode_result.value}'
-        if self.vmaf_result is not EncodeTestResult.SUCCESS:
+        if self.decode_result is not CodecTestResult.SUCCESS:
+            return f'{s} → Decode {self.decode_result.value}'
+        if self.vmaf_result is not CodecTestResult.SUCCESS:
             return f'{s} → VMAF {self.vmaf_result.value}'
-        time = self.encode_time + self.vmaf_time
+        time = self.encode_time + self.decode_time + self.vmaf_time
         return f'{s} [{time:.3f}s] → {self.vmaf_score:.5f}'
 
 
@@ -85,51 +91,163 @@ class Test:  # pylint: disable=too-few-public-methods
     def __init__(self, params: Params):
         self.params = params
 
+    def convert_yuv_to_y4m(self, yuv_filepath: str, y4m_filepath: str,
+                           width: int, height: int,
+                           framerate: str = "24:1") -> None:
+        """Convert YUV420P file to Y4M format"""
+        # Input validation
+        if width <= 0 or height <= 0:
+            raise ValueError(f"Invalid dimensions: width={width}, "
+                             f"height={height}")
+
+        frame_size = width * height * 3 // 2  # YUV420P: Y + U/2 + V/2
+
+        try:
+            with open(yuv_filepath, 'rb') as yuv_file:
+                with open(y4m_filepath, 'w+b') as y4m_file:
+                    # Write Y4M header
+                    header = (f"YUV4MPEG2 W{width} H{height} F{framerate} "
+                              f"Ip A1:1 C420\n")
+                    y4m_file.write(header.encode('ascii'))
+
+                    frame_count = 0
+                    while True:
+                        # Read one frame of YUV data
+                        frame_data = yuv_file.read(frame_size)
+                        if len(frame_data) != frame_size:
+                            break
+
+                        # Write frame header
+                        y4m_file.write(b"FRAME\n")
+                        # Write frame data
+                        y4m_file.write(frame_data)
+                        frame_count += 1
+
+                    if self.params.verbose:
+                        print(f"Converted {frame_count} frames from YUV to "
+                              f"Y4M format")
+        except IOError as e:
+            raise IOError(f"Failed to convert YUV to Y4M: {e}") from e
+
     def run(self, result: Result) -> None:
         """Run the test"""
 
-        output_filepath = os.path.join(
+        encoded_filepath = os.path.join(
             self.params.output_dir,
-            self.params.asset[1].name + ".y4m"
+            self.params.asset[1].name + "_encoded" +
+            self.params.encoder.get_file_extension()
+        )
+        # Determine output file extension based on decoder
+        decoder = get_reference_decoder_for_codec(self.params.encoder.codec)
+        decoded_ext = ".y4m" if decoder and decoder.outputs_y4m else ".yuv"
+        decoded_filepath = os.path.join(
+            self.params.output_dir,
+            self.params.asset[1].name + "_decoded" + decoded_ext
         )
         input_filepath = os.path.join(
             self.params.resources_dir,
             self.params.asset[0],
             self.params.asset[1].filename,
         )
-        output_filepath = normalize_path(output_filepath)
+        encoded_filepath = normalize_path(encoded_filepath)
+        decoded_filepath = normalize_path(decoded_filepath)
         input_filepath = normalize_path(input_filepath)
 
         result.asset_fname = self.params.asset[1].filename
         result.encoder_name = self.params.encoder.name()
 
+        # Step 1: Encode
         try:
             start = perf_counter()
             self.params.encoder.encode(
                 input_filepath,
-                output_filepath,
+                encoded_filepath,
                 self.params.timeout,
                 self.params.verbose,
             )
             result.encode_time = perf_counter() - start
+            result.encode_result = CodecTestResult.SUCCESS
         except TimeoutExpired:
-            result.encode_result = EncodeTestResult.TIMEOUT
+            result.encode_result = CodecTestResult.TIMEOUT
             raise
-        except:  # noqa: E722
-            result.encode_result = EncodeTestResult.ERROR
+        except Exception:
+            result.encode_result = CodecTestResult.ERROR
             raise
-        finally:
-            result.encode_result = EncodeTestResult.SUCCESS
 
-        if result.encode_result is EncodeTestResult.SUCCESS:
+        # Step 2: Decode (only if encode was successful)
+        if result.encode_result is CodecTestResult.SUCCESS:
+            if decoder and decoder.check(self.params.verbose):
+                try:
+                    start = perf_counter()
+                    decoder.decode(
+                        encoded_filepath,
+                        decoded_filepath,
+                        OutputFormat.YUV420P,
+                        timeout=self.params.timeout,
+                        verbose=self.params.verbose,
+                    )
+                    result.decode_time = perf_counter() - start
+                    result.decode_result = CodecTestResult.SUCCESS
+
+                    # Convert YUV to Y4M if decoder outputs raw YUV
+                    if decoder and not decoder.outputs_y4m:
+                        y4m_filepath = decoded_filepath.replace('.yuv', '.y4m')
+                        try:
+                            asset = self.params.asset[1]
+                            self.convert_yuv_to_y4m(
+                                decoded_filepath,
+                                y4m_filepath,
+                                asset.width,
+                                asset.height
+                            )
+                            # Delete the YUV file after successful conversion
+                            os.remove(decoded_filepath)
+                            # Update decoded_filepath to point to Y4M file
+                            # for VMAF
+                            decoded_filepath = y4m_filepath
+                        except Exception as e:
+                            if self.params.verbose:
+                                print(f"YUV to Y4M conversion failed: {e}. "
+                                      f"Continue with original YUV file.")
+                except TimeoutExpired:
+                    result.decode_result = CodecTestResult.TIMEOUT
+                    raise
+                except Exception:
+                    result.decode_result = CodecTestResult.ERROR
+                    raise
+            else:
+                if self.params.verbose:
+                    print(f"No reference decoder available or usable "
+                          f"for codec {self.params.encoder.codec}")
+                result.decode_result = CodecTestResult.ERROR
+
+        # Step 3: VMAF (only if decode was successful)
+        if result.decode_result is CodecTestResult.SUCCESS:
             cmd = [
                 str(self.params.vmaf_binary),
                 '--quiet',
                 '--reference',
                 input_filepath,
                 '--distorted',
-                output_filepath
+                decoded_filepath
             ]
+
+            # Add resolution parameters only for raw YUV files
+            # Note: Y4M files contain metadata, so no additional parameters
+            # needed
+            if (decoder and not decoder.outputs_y4m and
+                    not decoded_filepath.endswith('.y4m')):
+                asset = self.params.asset[1]
+                cmd.extend([
+                    '--width',
+                    str(asset.width),
+                    '--height',
+                    str(asset.height),
+                    '--pixel_format',
+                    '420',
+                    '--bitdepth',
+                    '8'
+                ])
             try:
                 start = perf_counter()
                 output = run_command_with_output(
@@ -137,17 +255,17 @@ class Test:  # pylint: disable=too-few-public-methods
                     verbose=self.params.verbose,
                 )
                 result.vmaf_time = perf_counter() - start
-            except:  # noqa: E722
-                result.vmaf_result = EncodeTestResult.ERROR
-                raise
-            finally:
                 try:
                     result.vmaf_score = float(output.split(':')[1])
-                    result.vmaf_result = EncodeTestResult.SUCCESS
+                    result.vmaf_result = CodecTestResult.SUCCESS
                 except (IndexError, ValueError):
-                    result.vmaf_result = EncodeTestResult.FAIL
+                    result.vmaf_result = CodecTestResult.FAIL
+            except Exception:
+                result.vmaf_result = CodecTestResult.ERROR
+                raise
 
-        if not self.params.keep_files \
-           and os.path.exists(output_filepath) \
-           and os.path.isfile(output_filepath):
-            os.remove(output_filepath)
+        # Clean up temporary files
+        if not self.params.keep_files:
+            for filepath in [encoded_filepath, decoded_filepath]:
+                if os.path.exists(filepath) and os.path.isfile(filepath):
+                    os.remove(filepath)


### PR DESCRIPTION
In order to validate the output from a common source, the decoding stage should be performed by a reference decoder.
All the encoders are now using the same reference decoder.

Added a reference decoder for:

- H264
- H265
- VP9
- AV1

Fixing #12 

